### PR TITLE
Add workflow to run e2e tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,0 +1,41 @@
+name: E2E Tests
+on:
+   # Run on any commit to the #master branch
+   push:
+      branches: [master, develop]
+   # Run on pull requests into the #master branch
+   pull_request:
+      branches: [master, develop]
+   # Allows user to trigger the workflow from GitHub's web UI
+   workflow_dispatch:
+
+jobs:
+   cypress-test:
+      name: Run Tests
+      runs-on: ubuntu-latest
+      steps:
+         - name: Install AppBuilder
+           run: docker swarm init && npx digi-serve/ab-cli install ab --stack=ab --port=8080 --db.expose=false --db.password=root --db.encryption=false --tag=develop --nginx.enable=true --ssl.none --bot.enable=false --smtp.enable=false --tenant.username=admin --tenant.password=admin --tenant.email=neo@thematrix.com
+
+         - name: Check out api_sails
+           uses: actions/checkout@v2
+           with:
+              path: api_sails
+
+         - name: Build ab-api-sails docker image
+           run: docker build -t ab-api-sails:test .
+           working-directory: ./api_sails
+
+         - name: Deploy Stack
+           run: docker stack deploy -c docker-compose.yml -c docker-compose.override.yml -c ./test/setup/ci-test.overide.yml -c ../api_sails/ci-test.override.yml ab
+           working-directory: ./ab
+
+         - name: Run Cypress Tests
+           uses: cypress-io/github-action@v2
+           with:
+              working-directory: ./ab
+              project: ./test/e2e
+              config: baseUrl=http://localhost:8080,responseTimeout=60000
+              wait-on: "http://localhost:8080"
+              wait-on-timeout: 300
+              env: stack=ab

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -22,6 +22,12 @@ jobs:
            with:
               path: api_sails
 
+         - name: Check out kitchen-sink tests
+           uses: actions/checkout@v2
+           with:
+              repository: digi-serve/kitchensink_app
+              path: ab/test/e2e/cypress/integration/kitchensink_app
+
          - name: Build ab-api-sails docker image
            run: docker build -t ab-api-sails:test .
            working-directory: ./api_sails

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,10 @@
 
 FROM digiserve/service-cli:develop
 
-RUN git clone --recursive https://github.com/digi-serve/ab_service_api_sails.git app && cd app && git checkout develop && npm install
+COPY . /app
 
 WORKDIR /app
+
+RUN npm install
 
 CMD ["node", "--inspect=0.0.0.0:9229", "app_waitMysql.js"]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # apiSails
-[![Build Status](https://travis-ci.com/Hiro-Nakamura/ab_service_api_sails.svg?branch=develop)](https://travis-ci.com/Hiro-Nakamura/ab_service_api_sails)
 
+![E2E Tests](https://github.com/digi-serve/ab_service_api_sails/actions/workflows/e2e-tests.yml/badge.svg) ![Docker Build](https://github.com/digi-serve/ab_service_api_sails/actions/workflows/build-on-commit.yml/badge.svg)
 
 The api endpoint for our AppBuilder Runtime.

--- a/ci-test.override.yml
+++ b/ci-test.override.yml
@@ -1,0 +1,5 @@
+version: "3.2"
+# Use a locally built image not the dockerhub version
+services:
+   api_sails:
+      image: ab-api-sails:test


### PR DESCRIPTION
The biggest change is to the dockerfile. It was always building images from the develop, which I don't think is what we want. I switched it to use the locally checked out code.