### PR TITLE
add route to return definitions as js

### DIFF
--- a/api/controllers/SiteController.js
+++ b/api/controllers/SiteController.js
@@ -98,13 +98,7 @@ module.exports = {
       // we need to combine several config sources:
       // tenant: tenantManager.config (id:uuid)
       // user: userManager.config(id:uuid)
-      // definitions: definitionManager.config(roles:user.roles);
       // labels: appbuilder.labels("en")
-
-      var configDefinitions = null;
-      // {array} [ {ABDefinition}, {ABDefinition}, ...]
-      // The list of ABxxxx definitions to send to the Web client to create
-      // the applications to display.
 
       var configInbox = null;
       // {array} [ {ABDefinition}, {ABDefinition}, ...]
@@ -263,27 +257,6 @@ module.exports = {
 
                      async.parallel(
                         [
-                           // Pull the Definitions for this user
-                           (done) => {
-                              var jobData = {
-                                 roles: configUser.roles,
-                              };
-
-                              // pass the request off to the uService:
-                              req.ab.serviceRequest(
-                                 "definition_manager.definitionsForRoles",
-                                 jobData,
-                                 (err, results) => {
-                                    if (err) {
-                                       req.ab.log("error:", err);
-                                       return;
-                                    }
-                                    configDefinitions = results;
-                                    done();
-                                 }
-                              );
-                           },
-
                            // Pull the Inbox Items for this User
                            (done) => {
                               var jobData = {
@@ -354,7 +327,6 @@ module.exports = {
                })
                .then(() => {
                   res.ab.success({
-                     definitions: configDefinitions,
                      inbox: configInbox,
                      inboxMeta: configInboxMeta,
                      labels: configLabels,

--- a/api/controllers/definition_manager/definition-for-role.js
+++ b/api/controllers/definition_manager/definition-for-role.js
@@ -1,0 +1,43 @@
+/**
+ * definitions/for-roles/
+ *
+ *
+ * url:     get /definition/myapps
+ * header:  X-CSRF-Token : [token]
+ * params:
+ */
+
+module.exports = function (req, res) {
+   // Package the Request and pass it off to the service
+   req.ab.log(`definition_manager::definitionsForRoles`);
+   // verify User is able to access service:
+   if (!(req.ab.validUser(/* false */))) {
+      // an error message is automatically returned to the client
+      // so be sure to return here;
+      return;
+   }
+
+   // create a new job for the service
+   let jobData = {
+      roles: req.ab.user.SITE_ROLE,
+   };
+
+   // pass the request off to the uService:
+   req.ab.serviceRequest(
+      "definition_manager.definitionsForRoles",
+      jobData,
+      (err, result) => {
+         if (err) {
+            console.log("err", err);
+            res.ab.error(err);
+            return;
+         }
+         // Send as JS
+         res.set("Content-Type", "text/javascript");
+         // Cache for 1 year (if definitons are changes this will be requested
+         // with a new hash in the query param).
+         res.set("Cache-Control", "max-age=31536000");
+         res.send(`window.definitions=${JSON.stringify(result)}`);
+      }
+   );
+};

--- a/api/controllers/definition_manager/definitions-check-update.js
+++ b/api/controllers/definition_manager/definitions-check-update.js
@@ -1,0 +1,39 @@
+/**
+ * definitions/check-update/
+ *
+ *
+ * url:     get /definition/check-update
+ * header:  X-CSRF-Token : [token]
+ * params:
+ */
+
+module.exports = function (req, res) {
+   // Package the Request and pass it off to the service
+   req.ab.log(`definition_manager::definitions-check-update`);
+
+   // verify User is able to access service:
+   if (!(req.ab.validUser(/* false */))) {
+      // an error message is automatically returned to the client
+      // so be sure to return here;
+      return;
+   }
+
+   // create a new job for the service
+   let jobData = {};
+
+   // pass the request off to the uService:
+   req.ab.serviceRequest(
+      "definition_manager.definitions-check-update",
+      jobData,
+      (err, result) => {
+         if (err) {
+            console.log("err", err);
+            res.ab.error(err);
+            return;
+         }
+         // Send as JS
+         console.log("result", result);
+         res.ab.success(result);
+      }
+   );
+};


### PR DESCRIPTION
- remove definitions from main config
- return definitions as a js file and tell the browser to cache it
- add a route to check when definition's in the server-side cache were last updated