### PR TITLE
Hotfix: Stub AuthSwitcheroo.js so that sails can still come up.

### DIFF
--- a/api/policies/authSwitcheroo.js
+++ b/api/policies/authSwitcheroo.js
@@ -1,0 +1,5 @@
+/*
+ * AuthSwitcheroo Stub (Our config expects this policy now)
+ */
+
+module.exports = (req, res, next) => next();


### PR DESCRIPTION
AuthSwitcheroo policy is now expected because it has been added to our config service. Right now we get the error:  
```
error: Failed to lift app: userError: Invalid policy setting for `*`: `authSwitcheroo` does not correspond to any of the loaded policies.
```
This is affecting our ci tests. So stubbing the policy until #jh/switcheroo is ready to merge.
