### PR TITLE
[fix] Repeat Login

### DIFF
--- a/api/controllers/auth/login.js
+++ b/api/controllers/auth/login.js
@@ -44,7 +44,7 @@ module.exports = function (req, res) {
    req.ab.serviceRequest(
       "user_manager.user-find-password",
       { email, password },
-      (err, user) => {
+      async (err, user) => {
          if (err) {
             req.ab.log("error logging in:", err);
             res.ab.error(err, 401);
@@ -54,8 +54,10 @@ module.exports = function (req, res) {
          req.ab.log("successful auth/login");
          req.session.tenant_id = req.ab.tenantID;
          req.session.user_id = user.uuid;
+
+         // make response last so session is updated before next user interaction
+         await authLogger(req, "Local auth successful");
          res.ab.success({ user });
-         authLogger(req, "Local auth successful");
       }
    );
 };


### PR DESCRIPTION
I've noticed on a local development system that sometimes I have to login twice.

I think it is due to the `auth/login` handler sending a response to the USER's browser and then trying to perform another action after that.  On a local dev system, the Browser's next request can happen quick enough that the last action in the `auth/login` handler isn't yet complete, and therefore hasn't updated the user's session with the auth credentials.  So that next request is redirected to the Login page. 

Making the response to the User's browser the last action should fix this problem.