### PR TITLE
Healthcheck to ping AppBuilder services

### DIFF
--- a/api/controllers/SiteController.js
+++ b/api/controllers/SiteController.js
@@ -316,7 +316,7 @@ module.exports = {
    },
 
    /*
-    * get /plugin/:key
+    * get /plugin/:tenant/:key
     * return the proper path for the plugin requested for this Tenant.
     */
    pluginLoad: function (req, res) {

--- a/api/hooks/healthcheck.js
+++ b/api/hooks/healthcheck.js
@@ -45,6 +45,78 @@ const servicesToPing = [
    "notification_email"
 ];
 
+// This provides the req.ab.* methods.
+const utilPolicy = require("../policies/abUtils.js");
+
+/**
+ * The healthcheck endpoint handler.
+ * "GET /healthcheck"
+ * 
+ * @param {HTTPRequest} req
+ * @param {HTTPResponse} res
+ */
+const healthcheck = function(req, res) {
+   let pings = [];
+   let results = {
+   /*
+      <service>: { 
+         isHealthy: <boolean>,
+         message: <string>,
+         startTime: <Date>,
+         endTime: <Date>,
+         msElapsed: <int>
+      },
+      ...
+   */
+   };
+   let statusCode = 200;
+
+   servicesToPing.forEach((service) => {
+      results[service] = {
+         isHealthy: null,
+         message: null,
+         startTime: new Date(),
+         endTime: null,
+         msElapsed: null
+      };
+      // Ping all services in parallel
+      pings.push(new Promise((resolve) => {
+         let pingResponse = results[service];
+         req.ab.serviceRequest(
+            `${service}.healthcheck`,
+            {},
+            (err, data = "") => {
+               pingResponse.endTime = new Date();
+               pingResponse.msElapsed = pingResponse.endTime - pingResponse.startTime;
+               if (err) {
+                  pingResponse.isHealthy = false;
+                  pingResponse.message = err.message || err;
+                  // 207 Multi-Status: some services are not OK
+                  statusCode = 207;
+               } else {
+                  pingResponse.isHealthy = true;
+                  pingResponse.message = data;
+               }
+               resolve();
+            }
+         );
+      }));
+   });
+
+   Promise.all(pings)
+      .then(() => {
+         res.status(statusCode).json(results);
+      })
+      .catch((err) => {
+         // This should only happen if there's an error in api_sails
+         req.ab.error("Error while running healthcheck");
+         req.ab.error(err);
+         req.ab.log(results);
+         res.serverError(err);
+      });   
+}
+
+
 module.exports = function (sails) {
    return {
       routes: {
@@ -52,64 +124,10 @@ module.exports = function (sails) {
          before: {
 
             "GET /healthcheck": (req, res) => {
-               let pings = [];
-               let results = {
-               /*
-                  <service>: { 
-                     isHealthy: <boolean>,
-                     message: <string>,
-                     startTime: <Date>,
-                     endTime: <Date>,
-                     msElapsed: <int>
-                  },
-                  ...
-               */
-               };
-               let statusCode = 200;
-
-               servicesToPing.forEach((service) => {
-                  results[service] = {
-                     isHealthy: null,
-                     message: null,
-                     startTime: new Date(),
-                     endTime: null,
-                     msElapsed: null
-                  };
-                  // Ping all services in parallel
-                  pings.push(new Promise((resolve) => {
-                     let pingResponse = results[service];
-                     req.ab.serviceRequest(
-                        `${service}.healthcheck`,
-                        {},
-                        (err, data = "") => {
-                           pingResponse.endTime = new Date();
-                           pingResponse.msElapsed = pingResponse.endTime - pingResponse.startTime;
-                           if (err) {
-                              pingResponse.isHealthy = false;
-                              pingResponse.message = err.message || err;
-                              // 207 Multi-Status: some services are not OK
-                              statusCode = 207;
-                           } else {
-                              pingResponse.isHealthy = true;
-                              pingResponse.message = data;
-                           }
-                           resolve();
-                        }
-                     );
-                  }));
+               // Manually invoke the AB utils policy
+               utilPolicy(req, res, () => {
+                  healthcheck(req, res);
                });
-
-               Promise.all(pings)
-                  .then(() => {
-                     res.status(statusCode).json(results);
-                  })
-                  .catch((err) => {
-                     // This should only happen if there's an error in api_sails
-                     req.ab.error("Error while running healthcheck");
-                     req.ab.error(err);
-                     req.ab.log(results);
-                     res.serverError(err);
-                  });
             },
 
          },

--- a/api/hooks/healthcheck.js
+++ b/api/hooks/healthcheck.js
@@ -5,8 +5,9 @@
  * Authentication is not needed. The response will be the same regardless of
  * the tenant.
  * 
- * Services must implement a `*.healthcheck` handler. The handler takes no
- * arguments and returns an optional message with its ping response.
+ * Services can implement a `*.healthcheck` handler. The handler takes no
+ * arguments and returns an optional message with its ping response. If no
+ * handler is provded by the service, a default basic handler will be used.
  * 
  * // Example service handler
  * // - ab_service_example

--- a/api/hooks/healthcheck.js
+++ b/api/hooks/healthcheck.js
@@ -1,0 +1,118 @@
+/**
+ * API endpoint that pings every AppBuilder internal service to check if they
+ * are all healthy. 
+ * 
+ * Authentication is not needed. The response will be the same regardless of
+ * the tenant.
+ * 
+ * Services must implement a `*.healthcheck` handler. The handler takes no
+ * arguments and returns an optional message with its ping response.
+ * 
+ * // Example service handler
+ * // - ab_service_example
+ * // - ./handlers/healthcheck.js
+ * module.exports = {
+ *    key: "example.healthcheck",
+ *    inputValidation: {},
+ *    fn: function handler(req, cb) {
+ *       ABBootstrap.init(req)
+ *          .then((AB) => {
+ *             // Perform any internal checks if needed.
+ *             // - check DB connection?
+ *             // - check mail server?
+ *             // - check relay server?
+ *             // - throw Error("Your example message") if something is wrong
+ *             // ...
+ *             let message = "OK";
+ *             cb(null, message);
+ *          })
+ *          .catch((err) => {
+ *             cb(err);
+ *          });
+ *    }
+ * }
+ */
+
+const servicesToPing = [
+   "appbuilder",
+   "bot_manager",
+   "log_manager",
+   "process_manager",
+   "tenant_manager",
+   "user_manager",
+   "file_processor",
+   "relay",
+   "notification_email"
+];
+
+module.exports = function (sails) {
+   return {
+      routes: {
+         // These routes will run before any policies
+         before: {
+
+            "GET /healthcheck": (req, res) => {
+               let pings = [];
+               let results = {
+               /*
+                  <service>: { 
+                     isHealthy: <boolean>,
+                     message: <string>,
+                     startTime: <Date>,
+                     endTime: <Date>,
+                     msElapsed: <int>
+                  },
+                  ...
+               */
+               };
+               let statusCode = 200;
+
+               servicesToPing.forEach((service) => {
+                  results[service] = {
+                     isHealthy: null,
+                     message: null,
+                     startTime: new Date(),
+                     endTime: null,
+                     msElapsed: null
+                  };
+                  // Ping all services in parallel
+                  pings.push(new Promise((resolve) => {
+                     let pingResponse = results[service];
+                     req.ab.serviceRequest(
+                        `${service}.healthcheck`,
+                        {},
+                        (err, data = "") => {
+                           pingResponse.endTime = new Date();
+                           pingResponse.msElapsed = pingResponse.endTime - pingResponse.startTime;
+                           if (err) {
+                              pingResponse.isHealthy = false;
+                              pingResponse.message = err.message || err;
+                              // 207 Multi-Status: some services are not OK
+                              statusCode = 207;
+                           } else {
+                              pingResponse.isHealthy = true;
+                              pingResponse.message = data;
+                           }
+                           resolve();
+                        }
+                     );
+                  }));
+               });
+
+               Promise.all(pings)
+                  .then(() => {
+                     res.status(statusCode).json(results);
+                  })
+                  .catch((err) => {
+                     // This should only happen if there's an error in api_sails
+                     req.ab.error("Error while running healthcheck");
+                     req.ab.error(err);
+                     req.ab.log(results);
+                     res.serverError(err);
+                  });
+            },
+
+         },
+      },
+   };
+};

--- a/api/hooks/healthcheck.js
+++ b/api/hooks/healthcheck.js
@@ -33,6 +33,9 @@
  * }
  */
 
+// Add or modify your services here. Each service should have a basic
+// handler for <service name>.healthcheck. In addition, a service can have
+// a real request for testing.
 const servicesToPing = [
    {
       name: "bot_manager",
@@ -50,7 +53,7 @@ const servicesToPing = [
       name: "appbuilder",
       test: {
          request: "appbuilder.model-get",
-         params: { objectID: "228e3d91-5e42-49ec-b37c-59323ae433a1" }
+         params: { objectID: "228e3d91-5e42-49ec-b37c-59323ae433a1", cond: {} }
       }
    },
    {
@@ -84,16 +87,16 @@ const servicesToPing = [
    {
       name: "user_manager",
       test: {
-         request: "user_manager.find",
+         request: "user_manager.user-find",
          params: { username: "admin" }
       }
    },
    {
       name: "custom_reports",
-      test: {
-         request: "custom_reports.report",
-         params: { reportKey: "hello-world" }
-      }
+      //test: {
+      //   request: "custom_reports.report",
+      //   params: { "reportKey": "hello-world", data: {} }
+      //}
    },
 ];
 
@@ -141,10 +144,6 @@ const healthcheck = function(req, res) {
          ping: {
             message: null,
             time: null,
-         },
-         test: {
-            message: null,
-            time: null
          }
       };
 
@@ -177,6 +176,10 @@ const healthcheck = function(req, res) {
          pings.push(new Promise((resolve) => {
             let response = results[service.name];
             let startTime = new Date();
+            response.test = {
+               message: null,
+               time: null
+            };
             req.ab.serviceRequest(
                service.test.request,
                service.test.params,

--- a/api/hooks/healthcheck.js
+++ b/api/hooks/healthcheck.js
@@ -45,6 +45,8 @@ const servicesToPing = [
    "notification_email"
 ];
 
+const PING_TIMEOUT = 10000; // 10 seconds
+
 // This provides the req.ab.* methods.
 const utilPolicy = require("../policies/abUtils.js");
 
@@ -70,6 +72,9 @@ const healthcheck = function(req, res) {
    */
    };
    let statusCode = 200;
+   if (req.ab.tenantID == "??") {
+      req.ab.tenantID = "admin";
+   }
 
    servicesToPing.forEach((service) => {
       results[service] = {
@@ -84,7 +89,8 @@ const healthcheck = function(req, res) {
          let pingResponse = results[service];
          req.ab.serviceRequest(
             `${service}.healthcheck`,
-            {},
+            {}, // data
+            { maxAttempts: 1, timeout: PING_TIMEOUT }, // options
             (err, data = "") => {
                pingResponse.endTime = new Date();
                pingResponse.msElapsed = pingResponse.endTime - pingResponse.startTime;


### PR DESCRIPTION
This is a new `GET /healthcheck` API route that pings every AppBuilder internal service to check if they are all healthy. 

The default service ping responder is defined in `ab-utils/utils/defaultHealthcheck.js`. Individual services can also implement their own custom ping responder if needed.

(The work for this was actually done some time ago, but it had to wait for all the service images to update their ab-utils to the new version.)