### PR TITLE
Fix for: Cannot read property 'mcc' of undefined

### DIFF
--- a/api/policies/authUser.js
+++ b/api/policies/authUser.js
@@ -110,6 +110,7 @@ const isUserKnown = (req, res, next) => {
       let parts = req.headers["authorization"].split("@@@");
       if (
          parts[0] == "relay" &&
+         sails.config.relay?.mcc?.enabled &&
          parts[1] == sails.config.relay.mcc.accessToken
       ) {
          userID = parts[2];

--- a/config/local.js
+++ b/config/local.js
@@ -55,6 +55,26 @@ module.exports = {
       maxBytes: env("FILE_PROCESSOR_MAXBYTES", 10000000),
    },
 
+   relay: {
+      /*************************************************************************/
+      /* Mobile Comm Center (mcc)                                              */
+      /* The ab_service_relay sends http requests to ab_api_sails              */
+      /* and it uses the accessToken as part of its authentication.            */
+      /* See also: ab_service_relay > ./config/local.js                        */
+      /*************************************************************************/
+      mcc: {
+         /**********************************************************************/
+         /* enable: {bool} is communicating with our MCC enabled?              */
+         /**********************************************************************/
+         enabled: env("RELAY_ENABLE", true),
+
+         /**********************************************************************/
+         /* accessToken: {string} required accessToken for sails to accept     */
+         /**********************************************************************/
+         accessToken: env("RELAY_SERVER_TOKEN", "There is no spoon."),
+      },
+   },
+
    http: {
       trustProxy: true,
    },


### PR DESCRIPTION
The `relay` config settings used to be in a common local.js file shared among all containers. Now with `awsReady`, each container has its own local.js settings. The relay settings were probably excluded from the api_sails container because ab_relay is the one that uses them.

But api_sails does use one part of the mcc settings for authenticating relay requests. This adds that back in.