### PR TITLE
Fix the cached user from being modified

### DIFF
--- a/api/lib/cacheManager.js
+++ b/api/lib/cacheManager.js
@@ -68,9 +68,9 @@ module.exports = {
       }
       CacheAuthUser[tenantID] = CacheAuthUser[tenantID] || {};
       if (typeof value === "undefined") {
-         return JSON.parse(JSON.stringify(CacheAuthUser[tenantID][userID]));
+         return structuredClone(CacheAuthUser[tenantID][userID]);
       }
-      CacheAuthUser[tenantID][userID] = JSON.parse(JSON.stringify(value));
+      CacheAuthUser[tenantID][userID] = structuredClone(value);
    },
 
    PreloaderSite: function (tenantID, config) {

--- a/api/lib/cacheManager.js
+++ b/api/lib/cacheManager.js
@@ -68,9 +68,9 @@ module.exports = {
       }
       CacheAuthUser[tenantID] = CacheAuthUser[tenantID] || {};
       if (typeof value === "undefined") {
-         return CacheAuthUser[tenantID][userID];
+         return JSON.parse(JSON.stringify(CacheAuthUser[tenantID][userID]));
       }
-      CacheAuthUser[tenantID][userID] = value;
+      CacheAuthUser[tenantID][userID] = JSON.parse(JSON.stringify(value));
    },
 
    PreloaderSite: function (tenantID, config) {


### PR DESCRIPTION
I ran into some situations where the user data in the cached no longer had any Roles assigned.

This patch prevents downstream handlers from modifying the data in the Cached User store.

## Release Notes
<!-- #release_notes -->
- [wip] make sure the Cached User data is cloned so downstream modifications wont effect the Cache
- [fix] ignore the cached user if it doesn't have any ROLES assigned.
<!-- /release_notes --> 
