### PR TITLE
Add new Testing Tools

### DIFF
--- a/api/hooks/testLog.js
+++ b/api/hooks/testLog.js
@@ -1,0 +1,45 @@
+/**
+ * API endpoint that simply dumps out a log string onto the console.
+ *
+ * This is primarily a Testing Feature so we can mark the beginning of a test run
+ * in the outgoing logs to aid our debugging of tests.
+ */
+
+// This provides the req.ab.* methods.
+const utilPolicy = require("../policies/abUtils.js");
+
+const testLog = function (req, res) {
+   // if this isn't in the testing environment, 404!
+   if (typeof process.env.AB_TESTING == "undefined") {
+      return res.notFound();
+   }
+
+   let logEntry = req.param("log");
+   if (!logEntry) {
+      return res.ab.success({ log: "not provided" });
+   }
+
+   let delim = Array(logEntry.length).fill("#").join("");
+
+   req.ab.log(`######${delim}######`);
+   req.ab.log(`##### ${logEntry} #####`);
+   req.ab.log(`######${delim}######`);
+
+   res.ab.success({ done: true });
+};
+
+module.exports = function (sails) {
+   return {
+      routes: {
+         // These routes will run before any policies
+         before: {
+            "POST /testlog": (req, res) => {
+               // Manually invoke the AB utils policy
+               utilPolicy(req, res, () => {
+                  testLog(req, res);
+               });
+            },
+         },
+      },
+   };
+};

--- a/api/hooks/versionCheck.js
+++ b/api/hooks/versionCheck.js
@@ -60,7 +60,6 @@ const versioncheck = function (req, res) {
       <service> : "<version>"
       */
    };
-   let statusCode = 200;
    if (req.ab.tenantID == "??") {
       req.ab.tenantID = "admin";
    }

--- a/api/hooks/versionCheck.js
+++ b/api/hooks/versionCheck.js
@@ -1,0 +1,131 @@
+/**
+ * API endpoint that pings every AppBuilder internal service to gather their
+ * version information.
+ *
+ * Authentication is not needed. The response will be the same regardless of
+ * the tenant.
+ *
+ * Services can implement a `*.versionCheck` handler. The handler takes no
+ * arguments and returns text representation of their current version: 0.0.0
+ *
+ * // Example service handler
+ * // - ab_service_example
+ * // - ./handlers/versioncheck.js
+ * module.exports = {
+ *    key: "example.versioncheck",
+ *    inputValidation: {},
+ *    fn: function handler(req, cb) {
+ *       cb(null, this.controller.version);
+ *    }
+ * }
+ */
+
+// Add or modify your services here. Each service should have a basic
+// handler for <service name>.versioncheck.
+const servicesToPing = [
+   "appbuilder",
+   "custom_reports",
+   "definition_manager",
+   "file_processor",
+   "log_manager",
+   "notification_email",
+   "process_manager",
+   "relay",
+   "tenant_manager",
+   "user_manager",
+];
+
+const PING_TIMEOUT = 30000; // default 30 seconds
+
+// This provides the req.ab.* methods.
+const utilPolicy = require("../policies/abUtils.js");
+
+/**
+ * The healthcheck endpoint handler.
+ * "GET /healthcheck"
+ *
+ * Optional querystring param:
+ *   timeout
+ *
+ * Sends status code 200 if all services are OK.
+ * Sends status code 207 if one or more services are not OK.
+ *
+ * @param {HTTPRequest} req
+ * @param {HTTPResponse} res
+ */
+const versioncheck = function (req, res) {
+   let pings = [];
+   let results = {
+      /*
+      <service> : "<version>"
+      */
+   };
+   let statusCode = 200;
+   if (req.ab.tenantID == "??") {
+      req.ab.tenantID = "admin";
+   }
+
+   servicesToPing.forEach((service) => {
+      results[service] = "--";
+
+      // Ping all services in parallel
+      pings.push(
+         new Promise((resolve) => {
+            req.ab.serviceRequest(
+               `${service}.versioncheck`,
+               {}, // data
+               {
+                  maxAttempts: 1,
+                  timeout: req.query.timeout ?? PING_TIMEOUT,
+               },
+               (err, data = "") => {
+                  // Disabled services are OK.
+                  if (err?.message == "Service is disabled.") {
+                     results[service] = "disabled.";
+                  }
+                  // Other errors are not OK.
+                  else if (err) {
+                     results[service] = err.message || err;
+                  }
+                  // OK
+                  else {
+                     results[service] = data;
+                  }
+                  resolve();
+               }
+            );
+         })
+      );
+   });
+
+   Promise.all(pings)
+      .then(() => {
+         req.ab.log("versioncheck", results);
+         res.set("Content-Type", "application/json")
+            .status(200)
+            .send(JSON.stringify(results, null, 2));
+      })
+      .catch((err) => {
+         // This should only happen if there's an error in api_sails
+         req.ab.error("Error while running versioncheck");
+         req.ab.error(err);
+         req.ab.log(results);
+         res.serverError(err);
+      });
+};
+
+module.exports = function (sails) {
+   return {
+      routes: {
+         // These routes will run before any policies
+         before: {
+            "GET /versioncheck": (req, res) => {
+               // Manually invoke the AB utils policy
+               utilPolicy(req, res, () => {
+                  versioncheck(req, res);
+               });
+            },
+         },
+      },
+   };
+};

--- a/config/bootstrap.js
+++ b/config/bootstrap.js
@@ -58,9 +58,17 @@ module.exports.bootstrap = async function (done) {
       ReqAB.serviceRequest("tenant_manager.config.list", {}, (err, results) => {
          let list = results || [];
          configTenant(list, (err) => {
-            console.log("####################################################");
-            console.log("###### Bootstrap Caching Site Config Complete ######");
-            console.log("####################################################");
+            sails.request("GET /versioncheck", (err, data) => {
+               console.log(
+                  "####################################################"
+               );
+               console.log(
+                  "###### Bootstrap Caching Site Config Complete ######"
+               );
+               console.log(
+                  "####################################################"
+               );
+            });
          });
       });
    });


### PR DESCRIPTION
Adding 2 new features for enhancing our ability to debug our failed e2e tests.  

New Route `get /versionCheck` will return (and print to console) the current versions of all our running services

New Route `POST /testlog` will insert a bold `log` statement into the running console logs being generated by the system.  This is handy for each of our e2e tests to begin by marking a log, so we can see all the activity generated by a specific test.

NOTE: this release depends on PR : [Create a default version check handler #67](https://github.com/digi-serve/ab-utils/pull/67)
## Release Notes
<!-- #release_notes -->
- [wip] Add new versionCheck and testLog features
<!-- /release_notes --> 
