### PR TITLE
Fix typo causing login errors not to be displayed

### DIFF
--- a/api/controllers/auth/login.js
+++ b/api/controllers/auth/login.js
@@ -20,7 +20,7 @@ module.exports = function (req, res) {
 
    passport.authenticate("local")(req, res, (err) => {
       if (err) {
-         res.ab.log("error logging in:", err);
+         req.ab.log("error logging in:", err);
          res.ab.error(err, 401);
       } else {
          req.ab.log("successful auth/login");


### PR DESCRIPTION
## Release Notes
<!-- #release_notes -->
- fixes issue displaying a login error message, introduced by refactoring auth
<!-- /release_notes --> 

## Test Status
<!-- Link to a new test, or explain why it's not needed -->
Tested in runtime test case #0001 (skipped temporarily to get the builds/releases done first)