### PR TITLE
Fix Reset Password

### DIFF
--- a/config/policies.js
+++ b/config/policies.js
@@ -25,6 +25,7 @@ module.exports.policies = {
 
    "mobile/app": noAuth,
    "mobile/favicon": noAuth,
+   "auth/reset-password-verify": noAuth,
 
    /***************************************************************************
     *                                                                          *

--- a/config/routes.js
+++ b/config/routes.js
@@ -178,6 +178,7 @@ module.exports.routes = {
    "get /config/site": "SiteController.configSite",
    "get /config/user": "SiteController.configUser",
    "get /config/inbox": "SiteController.configInbox",
+   "get /settings": "SiteController.settings",
 
    // System Information
    "get /definition/info/object/:ID": "definition_manager/information-object",

--- a/views/web_preloader.ejs
+++ b/views/web_preloader.ejs
@@ -39,6 +39,7 @@ async function Preload() {
    allScripts.push(ScriptLoad("/config/user?v=<%- configUserVersion %>"));
    // allScripts.push(ScriptLoad("/config/user/real"));
    allScripts.push(ScriptLoad("/definition/myapps?v=<%- configMyAppsVersion %>"));
+   allScripts.push(ScriptLoad("/settings"));
 
    let plugins = [ <%- pluginList %> ];
    plugins.forEach((p) => {


### PR DESCRIPTION
Fixes issue: digi-serve/ab_platform_web#555

Main issue is that our reset password flow use `settings.appbuilder-view` to display the form. Currently we include settings in site config, which is now cached, so the browser does not get the new setting.
## Release Notes
<!-- #release_notes -->
- settings, including `defaultView`, are now returned by `/settings`, which is not cached
- token in the reset password requests are now authenticated through passport
<!-- /release_notes --> 

## Test Status
<!-- Link to a new test, or explain why it's not needed -->
Tests to be added in https://github.com/digi-serve/ab_runtime/pull/401