### PR TITLE
Add HR plugin for relevant tenants

### DIFF
--- a/api/controllers/SiteController.js
+++ b/api/controllers/SiteController.js
@@ -567,6 +567,17 @@ module.exports = {
          pluginList.push("/assets/tenant/default/ABDesigner.js");
       }
 
+      const hrPluginTenants = [
+         // "admin", // <-- For local testing only
+         "1ad43361-d1da-47ac-9ee4-5e5bc6af512c",
+         "1729957e-d3ba-4cd4-901c-aa17982b9766",
+      ];
+
+      if (hrPluginTenants.includes(req.ab.tenantID)) {
+         console.log("Loading HR Teams Plugin");
+         pluginList.push(`/assets/tenant/default/HRTeams.js`);
+      }
+
       if (pluginList.length == 0) {
          pluginList = "";
       } else {

--- a/api/controllers/SiteController.js
+++ b/api/controllers/SiteController.js
@@ -569,8 +569,8 @@ module.exports = {
 
       const hrPluginTenants = [
          // "admin", // <-- For local testing only
-         "1ad43361-d1da-47ac-9ee4-5e5bc6af512c",
-         "1729957e-d3ba-4cd4-901c-aa17982b9766",
+         "1ad43361-d1da-47ac-9ee4-5e5bc6af512c", // ldhr.hrupdate.org
+         "1729957e-d3ba-4cd4-901c-aa17982b9766", // ldhr-test.hrupdate.org
       ];
 
       if (hrPluginTenants.includes(req.ab.tenantID)) {

--- a/api/controllers/definition/mobile-config-user.js
+++ b/api/controllers/definition/mobile-config-user.js
@@ -1,0 +1,78 @@
+/**
+ * definition/mobile-config-user.js
+ *
+ *
+ * url:     get /mobile/config-user
+ * header:  X-CSRF-Token : [token]
+ * params:
+ */
+
+var inputParams = {
+   /*    "email": { string:{ email: { allowUnicode: true }}, required:true }   */
+   /*                -> NOTE: put .string  before .required                    */
+   /*    "param": { required: true } // NOTE: param Joi.any().required();      */
+   /*    "param": { optional: true } // NOTE: param Joi.any().optional();      */
+};
+// { key : {validationObj} }
+//   key: the name of the input parameter passed into the api
+//   {validationObj} : description of the validation rules
+//        An object hash describing the validation checks to use. At
+//        the top level the Hash is: { [paramName] : {ruleHash} }
+//        Each {ruleHash} follows this format:
+//        "parameterName" : {
+//           {joi.fn}  : true,  // performs: joi.{fn}();
+//            {joi.fn} : {
+//              {joi.fn1} : true,   // performs: joi.{fn}().{fn1}();
+//              {joi.fn2} : { options } // performs: joi.{fn}().{fn2}({options})
+//            }
+//            // examples:
+//            "required" : {bool},  // default = false
+//
+//            // custom:
+//            "validation" : {fn} a function(value, {allValues hash}) that
+//                           returns { error:{null || {new Error("Error Message")} }, result: {normalize(value)}}
+//         }
+//        (see https://joi.dev/api)
+
+// make sure our BasePath is created:
+module.exports = function (req, res) {
+   // Package the Find Request and pass it off to the service
+
+   req.ab.log(`definition::mobile-config-user`);
+
+   // verify your inputs are correct:
+   // false : prevents an auto error response if detected. (default: true)
+   // valuesToCheck: {obj} a specified subset of the input values to validate.
+   //    { [key] : [value] }
+   //       [key] = inputParams[key] entry .
+   //       [value] = req.param(value)
+   //    if no values given, then req.allParams() are evaluated. In some cases
+   //    you'll want to only require a certain subset of input values and then
+   //    let the rest be evaluated by the destination service.
+   if (
+      !(req.ab.validUser(/* false */)) ||
+      !req.ab.validateParameters(inputParams /*, false , valuesToCheck*/)
+   ) {
+      // an error message is automatically returned to the client
+      // so be sure to return here;
+      return;
+   }
+
+   // create a new job for the service
+   let jobData = {
+      // param : req.ab.param("param");
+      //         req.ab.param() : returns values that have passed validation
+      //            and been normalized via the .validateParameters()
+      // param2: req.param("param2")
+      //         req.param()    : returns the raw values receive by sails.
+   };
+
+   // pass the request off to the uService:
+   req.ab.serviceRequest("definition.mobile-config-user", jobData, (err, results) => {
+      if (err) {
+         res.ab.error(err);
+         return;
+      }
+      res.ab.success(results);
+   });
+};

--- a/api/controllers/mobile/app-defs.js
+++ b/api/controllers/mobile/app-defs.js
@@ -1,0 +1,61 @@
+/**
+ * mobile/app-defs
+ *
+ * @api {GET} /mobile/definitions/:appID Mobile App definitions
+ * @apiPermission none
+ * @apiGroup Definition
+ * @apiSuccess (200) {text/javascript} definitions script to add the app definitions
+ */
+
+const inputParams = {
+   ID: { string: true, required: true },
+};
+
+module.exports = function (req, res) {
+   req.ab.log("mobile::Application Definitions");
+
+   // Handle the case where ?v=unknown (requested before login)
+   const v = req.query.v;
+   if (v === "unknown") {
+      res.set("Content-Type", "text/javascript");
+      res.set("Cache-Control", "max-age=31536000"); // Cache for 1 year
+      res.send(`window.definitions=[]`);
+      return;
+   }
+
+   // Validate input parameters
+   const validationParams = Object.keys(inputParams);
+   const valuesToCheck = {};
+   validationParams.forEach((p) => {
+      valuesToCheck[p] = req.query[p] || req.params[p]; // Check both query and URL params
+   });
+
+   if (
+      !req.ab.validUser() ||
+      !req.ab.validateParameters(inputParams, true, valuesToCheck)
+   ) {
+      return; // `validateParameters` automatically handles errors
+   }
+
+   // Create a job for the service request
+   const jobData = {
+      ID: valuesToCheck.ID,
+   };
+
+   req.ab.serviceRequest(
+      "definition_manager.definitions-app",
+      jobData,
+      { stringResult: true },
+      (err, result) => {
+         if (err) {
+            req.ab.log("Error fetching app definitions:", err);
+            return res.ab.error(err);
+         }
+
+         // Send response as JavaScript
+         res.set("Content-Type", "text/javascript");
+         res.set("Cache-Control", "max-age=31536000"); // Cache for 1 year
+         res.send(`window.__ab_definitions=${result}`);
+      }
+   );
+};

--- a/api/controllers/mobile/app.js
+++ b/api/controllers/mobile/app.js
@@ -2,14 +2,13 @@
  * mobile/app.js
  * @apiDescription Respond with the index.html of the Mobile PWA
  *
- * @api {get} /mobile/app/:appID App
+ * @api {get} /mobile/app/:tenantID/:appID
+ * @apiParam {string} tenantID
  * @apiParam {string} appID
  * @apiGroup Mobile
  * @apiPermission None
  * @apiSuccess (200) {HTML} html
  */
-const async = require("async");
-
 // var inputParams = {
 //    tenant: { string: true, optional: true },
 // };
@@ -21,68 +20,9 @@ module.exports = function (req, res) {
    let appID = req.ab.param("ID");
    let tenantID = req.ab.tenantID;
 
-   let config = null;
-   let definitions = null;
-
-   // create a new job for the service
-   let jobData = {
-      ID: appID,
-   };
-
-   async.parallel(
-      [
-         (done) => {
-            // pass the request off to the uService:
-            req.ab.serviceRequest(
-               "definition_manager.mobile-config",
-               jobData,
-               { stringResult: true },
-               // stringResult: true reduces the work of parsing the data
-               // and then restringifying it back into the res.view()
-               // configData here will be the stringify() version of the data
-               (err, configData) => {
-                  if (err) {
-                     done(err);
-                     return;
-                  }
-                  config = configData;
-                  done();
-               }
-            );
-         },
-         (done) => {
-            // pass the request off to the uService:
-            req.ab.serviceRequest(
-               "definition_manager.definitions-app",
-               jobData,
-               { stringResult: true },
-               // stringResult: true reduces the work of parsing the data
-               // and then restringifying it back into the res.view()
-               // definitionData here will be the stringify() version of the data
-               (err, definitionData) => {
-                  if (err) {
-                     done(err);
-                     return;
-                  }
-                  definitions = definitionData;
-                  done();
-               }
-            );
-         },
-      ],
-      (err) => {
-         if (err) {
-            res.ab.error(err, 500);
-            return;
-         }
-
-         res.view("mobile_pwa.ejs", {
-            layout: false,
-            appID,
-            tenantID,
-            config,
-            definitions,
-         });
-      }
-   );
+   res.view("mobile_pwa.ejs", {
+      layout: false,
+      appID,
+      tenantID,
+   });
 };

--- a/api/controllers/mobile/config-labels.js
+++ b/api/controllers/mobile/config-labels.js
@@ -1,0 +1,50 @@
+/**
+ * mobile/config-labels.js
+ *
+ *
+ * url:     get /mobile/config/labels/:appID
+ * header:  X-CSRF-Token : [token]
+ * params:
+ */
+
+module.exports = function (req, res) {
+   // Package the Find Request and pass it off to the service
+
+   req.ab.log(`mobile::config-labels`);
+
+   // verify your inputs are correct:
+   // Handle the case where ?v=unknown (requested before login)
+   const v = req.query.v;
+   if (v === "unknown" || !(req.ab.validUser(/* false */))) {
+      res.set("Content-Type", "text/javascript");
+      res.set("Cache-Control", "max-age=31536000"); // Cache for 1 year
+      res.send(`window.definitions=[]`);
+      return;
+   }
+
+   // default to "en" labels
+   const langCode = req.ab.user?.languageCode ?? "en";
+   const jobData = {
+      languageCode: langCode,
+   };
+   req.ab.log("label job data:", jobData);
+   req.ab.log("user:", req.ab.user);
+
+   // pass the request off to the uService:
+   req.ab.serviceRequest(
+      "appbuilder.labels",
+      jobData,
+      { stringResult: true },
+      (err, results) => {
+         if (err) {
+            req.ab.log("Error fetching appbuilder-labels:", err);
+            res.ab.error(err);
+            return;
+         }
+         // Send response as JavaScript
+         res.set("Content-Type", "text/javascript");
+         res.set("Cache-Control", "max-age=31536000"); // Cache for 1 year
+         res.send(`window.__ab_config.labels=${results}`);
+      }
+   );
+};

--- a/api/controllers/mobile/config-languages.js
+++ b/api/controllers/mobile/config-languages.js
@@ -1,0 +1,42 @@
+/**
+ * mobile/config-languages.js
+ *
+ *
+ * url:     get /mobile/config/languages/:appID
+ * header:  X-CSRF-Token : [token]
+ * params:
+ */
+
+module.exports = function (req, res) {
+   // Package the Find Request and pass it off to the service
+
+   req.ab.log(`mobile::config-languages`);
+
+   // verify your inputs are correct:
+   // Handle the case where ?v=unknown (requested before login)
+   const v = req.query.v;
+   if (v === "unknown" || !(req.ab.validUser(/* false */))) {
+      res.set("Content-Type", "text/javascript");
+      res.set("Cache-Control", "max-age=31536000"); // Cache for 1 year
+      res.send(`window.definitions=[]`);
+      return;
+   }
+
+   // pass the request off to the uService:
+   req.ab.serviceRequest(
+      "appbuilder.languages",
+      {},
+      { stringResult: true },
+      (err, results) => {
+         if (err) {
+            req.ab.log("Error fetching appbuilder-languages:", err);
+            res.ab.error(err);
+            return;
+         }
+         // Send response as JavaScript
+         res.set("Content-Type", "text/javascript");
+         res.set("Cache-Control", "max-age=31536000"); // Cache for 1 year
+         res.send(`window.__ab_config.languages=${results}`);
+      }
+   );
+};

--- a/api/controllers/mobile/config-meta.js
+++ b/api/controllers/mobile/config-meta.js
@@ -1,0 +1,42 @@
+/**
+ * mobile/config-meta.js
+ *
+ *
+ * url:     get /mobile/config/meta
+ * header:  X-CSRF-Token : [token]
+ * params:
+ */
+
+module.exports = function (req, res) {
+   // Package the Find Request and pass it off to the service
+
+   req.ab.log(`mobile::config-meta`);
+
+   // verify your inputs are correct:
+   // Handle the case where ?v=unknown (requested before login)
+   const v = req.query.v;
+   if (v === "unknown" || !(req.ab.validUser(/* false */))) {
+      res.set("Content-Type", "text/javascript");
+      res.set("Cache-Control", "max-age=31536000"); // Cache for 1 year
+      res.send(`window.definitions=[]`);
+      return;
+   }
+
+   // pass the request off to the uService:
+   req.ab.serviceRequest(
+      "user_manager.config-meta",
+      {},
+      { stringResult: true },
+      (err, results) => {
+         if (err) {
+            req.ab.log("Error fetching user_manager.config-meta:", err);
+            res.ab.error(err);
+            return;
+         }
+         // Send response as JavaScript
+         res.set("Content-Type", "text/javascript");
+         res.set("Cache-Control", "max-age=31536000"); // Cache for 1 year
+         res.send(`window.__ab_config.meta=${results}`);
+      }
+   );
+};

--- a/api/controllers/mobile/config-settings.js
+++ b/api/controllers/mobile/config-settings.js
@@ -1,0 +1,68 @@
+/**
+ * mobile/config-settings.js
+ *
+ *
+ * url:     get /mobile/config/settings/:appID
+ * header:  X-CSRF-Token : [token]
+ * params:
+ */
+
+var inputParams = {
+   appID: { string: true, required: true },
+};
+
+module.exports = function (req, res) {
+   // Package the Find Request and pass it off to the service
+
+   req.ab.log(`mobile::config-settings`);
+
+   // verify your inputs are correct:
+   // false : prevents an auto error response if detected. (default: true)
+   // valuesToCheck: {obj} a specified subset of the input values to validate.
+   // Handle the case where ?v=unknown (requested before login)
+   const v = req.query.v;
+   if (v === "unknown") {
+      res.set("Content-Type", "text/javascript");
+      res.set("Cache-Control", "max-age=31536000"); // Cache for 1 year
+      res.send(`window.definitions=[]`);
+      return;
+   }
+
+   // Validate input parameters
+   const validationParams = Object.keys(inputParams);
+   const valuesToCheck = {};
+   validationParams.forEach((p) => {
+      valuesToCheck[p] = req.query[p] || req.params[p]; // Check both query and URL params
+   });
+   if (
+      !(req.ab.validUser(/* false */)) ||
+      !req.ab.validateParameters(inputParams, true, valuesToCheck)
+   ) {
+      // an error message is automatically returned to the client
+      // so be sure to return here;
+      return;
+   }
+
+   // create a new job for the service
+   let jobData = {
+      ID: valuesToCheck.appID,
+   };
+
+   // pass the request off to the uService:
+   req.ab.serviceRequest(
+      "definition_manager.mobile-config-settings",
+      jobData,
+      { stringResult: true },
+      (err, results) => {
+         if (err) {
+            req.ab.log("Error fetching mobile-config-settings:", err);
+            res.ab.error(err);
+            return;
+         }
+         // Send response as JavaScript
+         res.set("Content-Type", "text/javascript");
+         res.set("Cache-Control", "max-age=31536000"); // Cache for 1 year
+         res.send(`window.__ab_config.settings=${results}`);
+      }
+   );
+};

--- a/api/controllers/mobile/config-tenants.js
+++ b/api/controllers/mobile/config-tenants.js
@@ -1,0 +1,47 @@
+/**
+ * mobile/config-tenants.js
+ *
+ *
+ * url:     get /mobile/config/tenants
+ * header:  X-CSRF-Token : [token]
+ * params:
+ */
+
+module.exports = function (req, res) {
+   // Package the Find Request and pass it off to the service
+
+   req.ab.log(`mobile::config-tenants`);
+
+   // verify your inputs are correct:
+   // Handle the case where ?v=unknown (requested before login)
+   const v = req.query.v;
+   if (v === "unknown" || !(req.ab.validUser(/* false */))) {
+      res.set("Content-Type", "text/javascript");
+      res.set("Cache-Control", "max-age=31536000"); // Cache for 1 year
+      res.send(`window.definitions=[]`);
+      return;
+   }
+
+   const jobData = {
+      uuid: req.ab.tenantID,
+   };
+   req.ab.log("/config jobData:", jobData);
+
+   // pass the request off to the uService:
+   req.ab.serviceRequest(
+      "tenant_manager.config",
+      jobData,
+      { stringResult: true },
+      (err, results) => {
+         if (err) {
+            req.ab.log("Error fetching tenant_manager.config:", err);
+            res.ab.error(err);
+            return;
+         }
+         // Send response as JavaScript
+         res.set("Content-Type", "text/javascript");
+         res.set("Cache-Control", "max-age=31536000"); // Cache for 1 year
+         res.send(`window.__ab_config.tenant=${results}`);
+      }
+   );
+};

--- a/api/controllers/mobile/config-user.js
+++ b/api/controllers/mobile/config-user.js
@@ -1,0 +1,62 @@
+/**
+ * mobile/config-user.js
+ *
+ *
+ * url:     get /mobile/config/user
+ * header:  X-CSRF-Token : [token]
+ * params:
+ */
+
+function UserSimple(req) {
+   let simpleUser = {};
+
+   Object.keys(req.ab.user).forEach((key) => {
+      if (key.indexOf("__relation") > -1) return;
+      if (key.indexOf("AB") == 0) return;
+      if (key.indexOf("SITE") == 0) return;
+      simpleUser[key] = req.ab.user[key];
+   });
+   return simpleUser;
+}
+
+// make sure our BasePath is created:
+module.exports = function (req, res) {
+   // Package the Find Request and pass it off to the service
+
+   req.ab.log(`mobile::config-user`);
+
+   // verify your inputs are correct:
+   // Handle the case where ?v=unknown (requested before login)
+   const v = req.query.v;
+   if (v === "unknown" || !(req.ab.validUser(/* false */))) {
+      res.set("Content-Type", "text/javascript");
+      res.set("Cache-Control", "max-age=31536000"); // Cache for 1 year
+      res.send(`window.definitions=[]`);
+      return;
+   }
+
+   // default to "en" labels
+   let simpleUser = UserSimple(req);
+
+   var jobData = {
+      user: simpleUser,
+   };
+
+   // pass the request off to the uService:
+   req.ab.serviceRequest(
+      "user_manager.config",
+      jobData,
+      { stringResult: true },
+      (err, results) => {
+         if (err) {
+            req.ab.log("Error fetching appbuilder-labels:", err);
+            res.ab.error(err);
+            return;
+         }
+         // Send response as JavaScript
+         res.set("Content-Type", "text/javascript");
+         res.set("Cache-Control", "max-age=31536000"); // Cache for 1 year
+         res.send(`window.__ab_config.user=${results}`);
+      }
+   );
+};

--- a/api/controllers/mobile/preloader.js
+++ b/api/controllers/mobile/preloader.js
@@ -1,0 +1,128 @@
+/**
+ * mobile/preloader.js
+ * @apiDescription Respond with the preloader of the Mobile PWA
+ *
+ * @api {get} /mobile/preloader/:tenantID/:appID
+ * @apiParam {uuid} tenantID
+ * @apiParam {uuid} appID
+ * @apiGroup Mobile
+ * @apiPermission None
+ * @apiSuccess (200) {HTML} html
+ */
+
+var inputParams = {
+   appID: { string: true, required: true },
+};
+
+module.exports = async function (req, res) {
+   req.ab.log("mobile/preloader():");
+
+   var validationParams = Object.keys(inputParams);
+
+   var valuesToCheck = {};
+   (validationParams || []).forEach((p) => {
+      valuesToCheck[p] = req.param(p);
+   });
+   if (
+      !(req.ab.validUser(/* false */)) ||
+      !req.ab.validateParameters(inputParams, true, valuesToCheck)
+   ) {
+      // an error message is automatically returned to the client
+      // so be sure to return here;
+      return;
+   }
+
+   let configUserRealData = req.ab.isSwitcherood() ? req.ab.userReal : 0;
+
+   let configMyAppsVersion;
+   if (!req.ab.user) {
+      // if we are not logged in: we don't need to perform lookups:
+      configMyAppsVersion = "unknown";
+   } else {
+      if (req.ab.isSwitcherood()) {
+         // should be a unique enough to bust the cache
+         configMyAppsVersion = req.ab.jobID;
+      } else {
+         try {
+            configMyAppsVersion = await lookupMyAppVersion(req);
+         } catch (err) {
+            req.ab.log("Error fetching app version:", err);
+            configMyAppsVersion = "error"; // Fallback to avoid breaking the view
+         }
+      }
+   }
+
+   let pluginList = "";
+
+   let tsConfigSettings = configMyAppsVersion;
+   // {timestamp}
+   // these settings come from the Application definitions, so we borrow the
+   // timestamp from our definitions as the settings here.
+
+   let tsConfigLabels = configMyAppsVersion;
+   // {timestamp}
+   // these settings come from the Application definitions, so we borrow the
+   // timestamp from our definitions as the settings here.
+
+   let tsConfigLanguages = configMyAppsVersion;
+   // {timestamp}
+   // these settings come from the Application definitions, so we borrow the
+   // timestamp from our definitions as the settings here.
+
+   let tsConfigUser = new Date(req.ab.user.updated_at).getTime();
+   // {timestamp}
+   // The user setting wont change until a new .updated_at is set.
+
+   // NOTE: the following are pulled in because they were needed in the
+   // web platform.  It's possible they are not needed in the PWA.
+   // We should review and remove if not needed.
+
+   let tsMeta = configMyAppsVersion;
+   // {timestamp}
+   // @todo: when should this be updated? Roles, Scopes, permissions, etc.
+   // NOTE: This might not be needed in PWA, it was pulled from web platform
+   // that also needed this for ABDesigner.
+
+   let tsTenants = configMyAppsVersion;
+   // {timestamp}
+   // @todo: when should this be updated? Site Tenant Information
+   // NOTE: This might not be needed in PWA, it was pulled from web platform
+   // that also needed this for ABDesigner.
+
+   res.type("text/javascript");
+   res.view("pwa_preloader.ejs", {
+      layout: false,
+      configUserRealData,
+      configMyAppsVersion,
+      pluginList,
+      appID: valuesToCheck.appID,
+      tsConfigSettings,
+      tsConfigLabels,
+      tsConfigLanguages,
+      tsConfigUser,
+      tsMeta,
+      tsTenants,
+   });
+
+   if (req.ab && req.ab.performance) {
+      req.ab.performance.log();
+   }
+};
+
+function lookupMyAppVersion(req) {
+   return new Promise((resolve, reject) => {
+      let appID = req.param("appID");
+      req.ab.serviceRequest(
+         "definition_manager.definitions-mobile-check-update",
+         { appID },
+         (err, results) => {
+            if (err) {
+               req.ab.log("error:", err);
+               reject(err);
+               return;
+            }
+            resolve(results);
+         }
+      );
+   });
+}

--- a/api/lib/broadcastManager.js
+++ b/api/lib/broadcastManager.js
@@ -76,7 +76,16 @@ ReqAB.serviceResponder("api.broadcast", (req, cb) => {
       };
 
       // pull the Sockets from the main d.room
-      let RoomSockets = sails.io.sockets.in(d.room);
+      // let RoomSockets = sails.io.sockets.in(d.room); // THIS retrieves ALL client sockets.
+      // console.log(
+      //    `NUMBER OF SOCKETS: ${Object.keys(RoomSockets.sockets).length} ${
+      //       d.event
+      //    } ${d.room}`
+      // );
+      let RoomSockets = sails.io.sockets.adapter.rooms?.[d.room] ?? {
+         sockets: {},
+      };
+
       Object.keys(RoomSockets.sockets).forEach((id) => {
          socketList[id] = RoomSockets.sockets[id];
       });

--- a/config/routes.js
+++ b/config/routes.js
@@ -172,6 +172,14 @@ module.exports.routes = {
    "get /mobile/app/:tenantID/:ID/manifest.json": "mobile/manifest",
    "get /mobile/app/:tenantID/:ID": "mobile/app",
    "get /mobile/qr/:ID": "mobile/qr",
+   "get /mobile/preloader/:tenantID/:appID": "mobile/preloader",
+   "get /mobile/definitions/:ID": "mobile/app-defs",
+   "get /mobile/config/settings/:appID": "mobile/config-settings",
+   "get /mobile/config/labels": "mobile/config-labels",
+   "get /mobile/config/languages": "mobile/config-languages",
+   "get /mobile/config/user": "mobile/config-user",
+   "get /mobile/config/meta": "mobile/config-meta",
+   "get /mobile/config/tenants": "mobile/config-tenants",
 
    // just testing our config-site :
    "get /config/preloader": "SiteController.preloader",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "app",
-  "version": "2.1.7",
+  "version": "2.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "app",
-      "version": "2.1.7",
+      "version": "2.1.10",
       "dependencies": {
-        "@digiserve/ab-utils": "^1.8.3",
+        "@digiserve/ab-utils": "^1.8.4",
         "@sailshq/connect-redis": "^3.2.1",
         "@sailshq/lodash": "^3.10.3",
         "@sailshq/socket.io-redis": "^5.2.0",
@@ -30,7 +30,7 @@
         "sails-hook-orm": "^4.0.0",
         "sails-hook-sockets": "^2.0.0",
         "sails-mysql": "^3.0.1",
-        "semver": "^7.6.3",
+        "semver": "^7.7.1",
         "shelljs": "^0.8.4",
         "shortid": "^2.2.15"
       },
@@ -301,9 +301,9 @@
       }
     },
     "node_modules/@digiserve/ab-utils": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@digiserve/ab-utils/-/ab-utils-1.8.3.tgz",
-      "integrity": "sha512-8xLFhKm/ay6F3ATE1QHfAiQovkvLstdiHlrvYQF1CbMuqLAkN5XmfH16wJKdDy48bPVUZxfS2Ub5LknjPL8urA==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/@digiserve/ab-utils/-/ab-utils-1.8.4.tgz",
+      "integrity": "sha512-GWHNTZ7FpMXs19Fgki4BlPqnPXvCO4pRG/lKeX2f4gBVyK79MxO7qi/SdAloA69owrseOt6Z5UiIx3elT2ZabQ==",
       "dependencies": {
         "@opentelemetry/api": "^1.4.1",
         "@opentelemetry/auto-instrumentations-node": "^0.39.2",
@@ -14710,9 +14710,10 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "app",
   "private": true,
-  "version": "2.1.8",
+  "version": "2.2.0",
   "description": "a Sails application",
   "keywords": [],
   "dependencies": {
-    "@digiserve/ab-utils": "^1.8.3",
+    "@digiserve/ab-utils": "^1.8.4",
     "@sailshq/connect-redis": "^3.2.1",
     "@sailshq/lodash": "^3.10.3",
     "@sailshq/socket.io-redis": "^5.2.0",
@@ -27,7 +27,7 @@
     "sails-hook-orm": "^4.0.0",
     "sails-hook-sockets": "^2.0.0",
     "sails-mysql": "^3.0.1",
-    "semver": "^7.6.3",
+    "semver": "^7.7.1",
     "shelljs": "^0.8.4",
     "shortid": "^2.2.15"
   },

--- a/views/mobile_pwa.ejs
+++ b/views/mobile_pwa.ejs
@@ -33,13 +33,32 @@
     <link rel="apple-touch-icon" href="icons/apple-touch-icon.png" />
     <link rel="icon" href="/mobile/app/<%= appID %>/favicon.png" />
     <link rel="manifest" href="/mobile/app/<%= tenantID %>/<%= appID %>/manifest.json" />
-    <script type='text/javascript'>
-      Window.__ab_config=<%- config %>;
-      Window.__ab_definitions=<%- definitions %>;
-    </script>
+    <script> 
+
+         //
+         // Setup some promises used during our boot up process.
+         //
+
+         // .__AB_preload  {Promise} our index.js script will await this 
+         // before continuing the Bootstrap.init();  This way all resources will
+         // be loaded before we start the initialization.
+         window.__AB_preload = new Promise((resolve) => {
+            window.__AB_preload_resolve = resolve;
+         });
+
+         // window.__AB_socketReady = new Promise((resolve) => {
+         //    window.__AB_socketReady_resolve = resolve;
+         // });
+
+         window.__ab_config = {};
+         // {json}
+         // a place holder for the incoming configuration settings loaded
+         // during the preloader script.
+      </script>
+      <script type='text/javascript' src='/mobile/preloader/<%= tenantID %>/<%= appID %>' defer></script>  
     <!-- built styles file will be auto injected -->
   </head>
   <body>
     <div id="app" appbuilder-tenant="<%= tenantID %>" ></div>
-  <script defer src="/assets/mobile/mobile_runtime.js"></script><script defer src="/assets/mobile/mobile_vendors.js"></script><script defer src="/assets/mobile/mobile_app.js"></script></body>
+  </body>
 </html>

--- a/views/pwa_preloader.ejs
+++ b/views/pwa_preloader.ejs
@@ -1,0 +1,65 @@
+
+
+window.__AB_Config_User_Real=<%- JSON.stringify(configUserRealData) %>
+// Setup the REAL User if switcherood():
+
+window.__AB_Plugins = [];
+// {array} our loaded plugins are stored here until Bootstrap
+// can pull them in.
+
+
+async function ScriptLoad(url) {
+   await new Promise((resolve, reject) => {
+      var cb = () => resolve();
+      // Adding the script tag to the head as suggested before
+      const head = document.head;
+      const script = document.createElement("script");
+      script.type = "text/javascript";
+      script.src = url;
+
+      // Then bind the event to the callback function.
+      // There are several events for cross browser compatibility.
+      script.onreadystatechange = cb;
+      script.onload = cb;
+      script.onerror = () => {
+         reject(
+            new Error(`Preloader:ScriptLoad(): Error loading script (${url})`)
+         );
+      };
+      // Fire the loading
+      head.appendChild(script);
+   });
+}
+
+async function Preload() {
+
+   let allScripts = [];
+
+
+   allScripts.push(ScriptLoad("/assets/mobile/mobile_runtime.js"));
+   allScripts.push(ScriptLoad("/assets/mobile/mobile_vendors.js"));
+   allScripts.push(ScriptLoad("/assets/mobile/mobile_app.js"));
+   // allScripts.push(ScriptLoad("/config/user/real"));
+   allScripts.push(ScriptLoad("/mobile/definitions/<%- appID %>?v=<%- configMyAppsVersion %>"));
+   allScripts.push(ScriptLoad("/mobile/config/settings/<%- appID %>?v=<%- tsConfigSettings %>"));
+   allScripts.push(ScriptLoad("/mobile/config/labels?v=<%- tsConfigLabels %>"));
+   allScripts.push(ScriptLoad("/mobile/config/languages?v=<%- tsConfigLanguages %>"));
+   allScripts.push(ScriptLoad("/mobile/config/user?v=<%- tsConfigUser %>"));
+   allScripts.push(ScriptLoad("/mobile/config/meta?v=<%- tsMeta %>"));
+   allScripts.push(ScriptLoad("/mobile/config/tenants?v=<%- tsTenants %>"));
+   // allScripts.push(ScriptLoad("/settings"));
+
+   let plugins = [ <%- pluginList %> ];
+   plugins.forEach((p) => {
+      allScripts.push(ScriptLoad(p));
+   })
+
+
+   await Promise.all(allScripts);
+
+   // wait for the socket.io library to be ready, then we are good to go:
+   // await window.__AB_socketReady;
+
+   window.__AB_preload_resolve();
+}
+Preload();


### PR DESCRIPTION
## Release Notes
As we're moving closer to HR Teams release, I want to move away from needing to maintain different branches and building manually. I packaged the HR Teams Complex Widget as a plugin, in the style of ABDesigner. But this requires modification to ABDesigner, platform_web and core to load the relevant classes. 

See the plugin code here: https://github.com/digi-serve/plugin_HRTeams

The main goal is code separation. I still think we need to work on a more accessible plugin system, that simplifies adding custom features to the platform.

📝 I'm merging into `jh/NetSuite` first, I think we can merge `jh/NetSuite` into `master` everywhere. 
📝 Only the last commit here is relevant 

<!-- #release_notes -->
-  Add HR plugin for relevant tenants
<!-- /release_notes --> 

## Test Status
<!-- Link to a new test, or explain why it's not needed -->
