### PR TITLE
Improve Performance by returning strings

### DIFF
--- a/api/controllers/appbuilder/model-get.js
+++ b/api/controllers/appbuilder/model-get.js
@@ -113,7 +113,10 @@ module.exports = function (req, res) {
       BroadcastManager.register(req);
    }
 
-   const options = {};
+   const options = {
+      stringResult: true,
+      // as a performance improvement, prevent JSON.parse()ing the results
+   };
    // if populate == true, then this might take longer, so mark this as a
    // longRequest
    // NOTE: only do this on a generic populate = true.  those can end up

--- a/api/controllers/appbuilder/model-post.js
+++ b/api/controllers/appbuilder/model-post.js
@@ -63,14 +63,19 @@ module.exports = function (req, res) {
       }
    });
 
-   req.ab.serviceRequest("appbuilder.model-post", jobData, (err, newItem) => {
-      BroadcastManager.unregister(req);
-      if (err) {
-         req.ab.log("api_sails:model-post:error:", err);
-         res.ab.error(err);
-         return;
-      }
+   req.ab.serviceRequest(
+      "appbuilder.model-post",
+      jobData,
+      { stringResult: true }, // prevent JSON.parse()ing the results
+      (err, newItem) => {
+         BroadcastManager.unregister(req);
+         if (err) {
+            req.ab.log("api_sails:model-post:error:", err);
+            res.ab.error(err);
+            return;
+         }
 
-      res.ab.success(newItem);
-   });
+         res.ab.success(newItem);
+      }
+   );
 };

--- a/api/controllers/appbuilder/model-update.js
+++ b/api/controllers/appbuilder/model-update.js
@@ -68,13 +68,18 @@ module.exports = function (req, res) {
       }
    });
 
-   req.ab.serviceRequest("appbuilder.model-update", jobData, (err, results) => {
-      if (err) {
-         req.ab.log("Error in model-update : ", err);
-         res.ab.error(err);
-         return;
-      }
+   req.ab.serviceRequest(
+      "appbuilder.model-update",
+      jobData,
+      { stringResult: true }, // prevent JSON.parse()ing the results
+      (err, results) => {
+         if (err) {
+            req.ab.log("Error in model-update : ", err);
+            res.ab.error(err);
+            return;
+         }
 
-      res.ab.success(results);
-   });
+         res.ab.success(results);
+      }
+   );
 };


### PR DESCRIPTION
I was noticing some Performance lags in our responses when our `api_sails` service handlers were having to `JSON.parse()` the responses before sending them off.

This patch will allow the service handlers to simply send back the strings un parsed.

However, this patch needs to [this PR](https://github.com/digi-serve/ab_platform_web/pull/648) in order to work.


## Release Notes
<!-- #release_notes -->
- [wip] improve performance on large json datasets by simply returning our results as strings.
<!-- /release_notes --> 

## Test Status
<!-- Link to a new test, or explain why it's not needed -->
