### PR TITLE
DataDog health checks for api_sails

### DIFF
--- a/api/controllers/SiteController.js
+++ b/api/controllers/SiteController.js
@@ -6,6 +6,9 @@
  */
 const async = require("async");
 const Cache = require("../lib/cacheManager");
+const path = require("node:path");
+
+const { version } = require(path.join(process.cwd(), "package.json"));
 
 function UserSimple(req) {
    let sUser = {};
@@ -478,6 +481,14 @@ module.exports = {
                });
          }
       );
+   },
+
+   /*
+    * get /monitors/lb
+    * return status 200 (and version number) if the server is up.
+    */
+   dataDog: function (req, res) {
+      res.status(200).send(`v${version}`);
    },
 
    /*

--- a/config/routes.js
+++ b/config/routes.js
@@ -202,4 +202,7 @@ module.exports.routes = {
    "get /netsuite/metadata": "appbuilder/netsuite-metadata-catalog",
    "get /netsuite/table/:ID": "appbuilder/netsuite-table-fields",
    "get /netsuite/dataverify/:table": "appbuilder/netsuite-data-verify",
+
+   // Cru Global DataDog /monitors/lb
+   "get /monitors/lb": "SiteController.dataDog",
 };


### PR DESCRIPTION
Implement a `GET monitors/lb` route to respond to our Cru Global Health Checks.

## Release Notes
<!-- #release_notes -->
- [wip] include a /monitors/lb route for the datadog health checks
<!-- /release_notes --> 

## Test Status
<!-- Link to a new test, or explain why it's not needed -->
